### PR TITLE
add support for pixeldrain links

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -21,7 +21,7 @@ namespace TootTallyCore
     [BepInIncompatibility("TootTally")]
     public class Plugin : BaseUnityPlugin
     {
-        public static int BUILDDATE = 20240125;
+        public static int BUILDDATE = 20240319;
         private const string DEFAULT_THEME = "Default";
 
         public static Plugin Instance;

--- a/TootTallyCore.csproj
+++ b/TootTallyCore.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<AssemblyName>TootTallyCore</AssemblyName>
 		<Description>TootTallyAPI for trombone champ modding</Description>
-		<Version>1.1.0</Version>
+		<Version>1.1.3</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>

--- a/Utils/Helpers/FileHelper.cs
+++ b/Utils/Helpers/FileHelper.cs
@@ -163,6 +163,8 @@ namespace TootTallyCore.Utils.Helpers
         private const string _DISCORD_DOWNLOAD_HEADER = "https://cdn.discordapp.com/";
         private const string _GOOGLEDRIVE_LINK_HEADER = "https://drive.google.com/file/d/";
         private const string _GOOGLEDRIVE_DOWNLOAD_HEADER = "https://drive.google.com/uc?export=download&id=";
+        private const string _PIXELDRAIN_DOWNLOAD_HEADER = "https://pixeldrain.com/u/";
+        private const string _PIXELDRAIN_DIRECT_DOWNLOAD_HEADER = "https://pixeldrain.com/api/file/";
         public static string GetDownloadLinkFromSongData(SongDataFromDB song)
         {
             if (song.mirror != null && Path.GetExtension(song.mirror).Contains(".zip"))
@@ -173,6 +175,10 @@ namespace TootTallyCore.Utils.Helpers
                     return song.download;
                 else if (song.download.Contains(_GOOGLEDRIVE_LINK_HEADER))
                     return GetGoogleDriveDownloadLink(song.download);
+                else if (song.download.Contains(_PIXELDRAIN_DOWNLOAD_HEADER))
+                    return song.download.Replace(_PIXELDRAIN_DOWNLOAD_HEADER, _PIXELDRAIN_DIRECT_DOWNLOAD_HEADER);
+                else if (song.download.Contains(_PIXELDRAIN_DIRECT_DOWNLOAD_HEADER))
+                    return song.download;
             }
             return null;
         }


### PR DESCRIPTION
lets you download charts such as this big boi
<img width="857" alt="image" src="https://github.com/TootTally/TootTallyCore/assets/15108194/2b95f25e-dfbb-42d6-afa1-cc6e6325cd45">