### PR TITLE
Add support for TromboneDB downloads

### DIFF
--- a/TootTallyCore.csproj
+++ b/TootTallyCore.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>TootTallyCore</AssemblyName>
     <Description>TootTally API for Trombone Champ modding</Description>
-    <Version>1.2.5</Version>
+    <Version>1.2.6</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 

--- a/Utils/Helpers/FileHelper.cs
+++ b/Utils/Helpers/FileHelper.cs
@@ -165,11 +165,12 @@ namespace TootTallyCore.Utils.Helpers
         private const string _GOOGLEDRIVE_DOWNLOAD_HEADER = "https://drive.google.com/uc?export=download&id=";
         private const string _PIXELDRAIN_DOWNLOAD_HEADER = "https://pixeldrain.com/u/";
         private const string _PIXELDRAIN_DIRECT_DOWNLOAD_HEADER = "https://pixeldrain.com/api/file/";
+        private const string _TROMBONEDB_DIRECT_DOWNLOAD_HEADER = "https://db.trombone.fyi/";
         public static string GetDownloadLinkFromSongData(SongDataFromDB song)
         {
             if (song.mirror != null && Path.GetExtension(song.mirror).Contains(".zip"))
                 return song.mirror;
-            else if (song.download != null)
+            else if (song.download != null && song.download != "")
             {
                 if (song.download.Contains(_DISCORD_DOWNLOAD_HEADER) && Path.GetExtension(song.download).Contains(".zip"))
                     return song.download;
@@ -178,6 +179,8 @@ namespace TootTallyCore.Utils.Helpers
                 else if (song.download.Contains(_PIXELDRAIN_DOWNLOAD_HEADER))
                     return song.download.Replace(_PIXELDRAIN_DOWNLOAD_HEADER, _PIXELDRAIN_DIRECT_DOWNLOAD_HEADER);
                 else if (song.download.Contains(_PIXELDRAIN_DIRECT_DOWNLOAD_HEADER))
+                    return song.download;
+                else if (song.download.Contains(_TROMBONEDB_DIRECT_DOWNLOAD_HEADER))
                     return song.download;
             }
             return null;

--- a/thunderstore/CHANGELOG.md
+++ b/thunderstore/CHANGELOG.md
@@ -1,5 +1,10 @@
 #### Changelog:
 
+`v1.2.5` -> `v1.2.6`
+```diff
++ Support for TromboneDB download links
+```
+
 `v1.2.2` -> `v1.2.5`
 ```diff
 + Added steam Auth logistic

--- a/thunderstore/README.md
+++ b/thunderstore/README.md
@@ -1,6 +1,6 @@
 # TootTally Companion Mod
 
-> Version: 1.2.5
+> Version: 1.2.6
 
 The [TootTally](https://toottally.com/)'s core libraries and API services
 

--- a/thunderstore/manifest.json
+++ b/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "TootTallyCore",
-    "version_number": "1.2.5",
+    "version_number": "1.2.6",
     "website_url": "https://github.com/TootTally/TootTallyCore",
     "description": "TootTally's core libraries and API services",
     "dependencies": [


### PR DESCRIPTION
This PR just adds support for downloading charts from TromboneDB download links (https://db.trombone.fyi)