### PR TITLE
Bump TromboneChamp.BaboonAPI and TromboneChamp.TrombLoader

### DIFF
--- a/TootTallyCore.csproj
+++ b/TootTallyCore.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
     <PackageReference Include="TromboneChamp.GameLibs" Version="1.27.0" />
-    <PackageReference Include="TromboneChamp.BaboonAPI" Version="2.9.0" />
-    <PackageReference Include="TromboneChamp.TrombLoader" Version="2.3.0" />
+    <PackageReference Include="TromboneChamp.BaboonAPI" Version="2.10.0" />
+    <PackageReference Include="TromboneChamp.TrombLoader" Version="2.4.3" />
     <PackageReference Include="UnityEngine.Modules" Version="2019.4.40" IncludeAssets="compile" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="websocket-sharp-customheaders" Version="1.0.2.31869" />


### PR DESCRIPTION
Bumps TromboneChamp.BaboonAPI from 2.9.0 to 2.10.0 Bumps TromboneChamp.TrombLoader from 2.3.0 to 2.4.3

---
updated-dependencies:
- dependency-name: TromboneChamp.BaboonAPI dependency-version: 2.10.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: TromboneChamp.TrombLoader dependency-version: 2.4.3 dependency-type: direct:production update-type: version-update:semver-minor ...